### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../CLAUDE.md
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,41 @@
-CLAUDE.md
+# AGENTS.md
+
+## Project purpose
+Older standalone repo of reusable GitHub Actions workflows for VyOS. Largely **superseded by `vyos/.github`** (the canonical org-wide reusable-workflow library, default branch `current`). Some VyOS-Networks-side and legacy repos still consume workflows from here; new work should target `vyos/.github`.
+
+## Tech stack
+- GitHub Actions YAML reusable workflows under `.github/workflows/`.
+- Python helper scripts under `scripts/` (`check-pr-title-and-commit-messages.py`, `override-default`, `transclude-template`).
+
+## Build / test / run
+N/A — consumed by other repos via:
+```
+uses: vyos/vyos-github-actions/.github/workflows/<name>.yml@<ref>
+```
+The Python helper scripts are invoked from the workflows.
+
+## Repository layout
+- `.github/workflows/` — reusable workflows: `codeql-analysis.yml`, `mergifyio_backport.yml`, `pr-conflicts.yml`, `pull-request-labels.yml`, `pull-request-management.yml`, `pull-request-message-check.yml`, `stale.yml`, `unused-imports.yml`, `cla-check.yml`, `auto-author-assign.yml`.
+- `scripts/`
+  - `check-pr-title-and-commit-messages.py` — PR-title/commit-message linter (`component: T12345: description`).
+  - `override-default` — XML preprocessor (also vendored in `vyos/.github/scripts/`, used by `vyos-1x`/`vyos-build`).
+  - `transclude-template` — XML `#include` preprocessor (same vendoring).
+- `README.md` — workflow inventory + usage snippets.
+
+## Cross-repo context
+- **Superseded by `vyos/.github@current`.** That canonical repo carries 19 workflow files and the modern mirror pipeline (`pr-mirror-repo-sync.yml`). Most active VyOS repos pin `vyos/.github`, not this repo.
+- The `override-default` and `transclude-template` scripts here are duplicated into `vyos/.github/scripts/` — they are runtime build-time helpers used by `vyos-1x` (XML interface-definition processing) and `vyos-build`.
+- Twin org-side library: `VyOS-Networks/vyos-reusable-workflows` (7 workflows, internal-only).
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Reusable-workflow pin model: callers reference these workflows with floating refs (no semver tags); changes ship to consumers immediately.
+- Default branch is the legacy default (typically `master`/`main`); confirm via `git ls-remote --symref` before pinning.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-github-actions`. Mirror pipeline not confirmed live; treat the `vyos/*` side as canonical for any remaining consumers.
+
+## Notes for future contributors
+- **New reusable workflows belong in `vyos/.github`, not here.** Add them at `vyos/.github/.github/workflows/<name>.yml` on `current`.
+- Before deleting a workflow from this repo, grep `vyos/*` and `VyOS-Networks/*` consumers for `uses: vyos/vyos-github-actions/...` — some legacy repos may still be pinned here.
+- The `scripts/override-default` and `scripts/transclude-template` are kept in sync with the copies in `vyos/.github/scripts/`. If you change one, change the other (or migrate fully to `vyos/.github`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project purpose
-Older standalone repo of reusable GitHub Actions workflows for VyOS. Largely **superseded by `vyos/.github`** (the canonical org-wide reusable-workflow library, default branch `current`). Some VyOS-Networks-side and legacy repos still consume workflows from here; new work should target `vyos/.github`.
+Older standalone repo of reusable GitHub Actions workflows for VyOS. Largely **superseded by `vyos/.github`** (the canonical org-wide reusable-workflow library, default branch `current`). Some the private side-side and legacy repos still consume workflows from here; new work should target `vyos/.github`.
 
 ## Tech stack
 - GitHub Actions YAML reusable workflows under `.github/workflows/`.
@@ -25,17 +25,12 @@ The Python helper scripts are invoked from the workflows.
 ## Cross-repo context
 - **Superseded by `vyos/.github@current`.** That canonical repo carries 19 workflow files and the modern mirror pipeline (`pr-mirror-repo-sync.yml`). Most active VyOS repos pin `vyos/.github`, not this repo.
 - The `override-default` and `transclude-template` scripts here are duplicated into `vyos/.github/scripts/` — they are runtime build-time helpers used by `vyos-1x` (XML interface-definition processing) and `vyos-build`.
-- Twin org-side library: `VyOS-Networks/vyos-reusable-workflows` (7 workflows, internal-only).
-
 ## Conventions
 - Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev).
 - Reusable-workflow pin model: callers reference these workflows with floating refs (no semver tags); changes ship to consumers immediately.
 - Default branch is the legacy default (typically `master`/`main`); confirm via `git ls-remote --symref` before pinning.
 
-## Mirror relationship
-Mirror twin: `VyOS-Networks/vyos-github-actions`. Mirror pipeline not confirmed live; treat the `vyos/*` side as canonical for any remaining consumers.
-
 ## Notes for future contributors
 - **New reusable workflows belong in `vyos/.github`, not here.** Add them at `vyos/.github/.github/workflows/<name>.yml` on `current`.
-- Before deleting a workflow from this repo, grep `vyos/*` and `VyOS-Networks/*` consumers for `uses: vyos/vyos-github-actions/...` — some legacy repos may still be pinned here.
+- Before deleting a workflow from this repo, grep `vyos/*` and an internal repository consumers for `uses: vyos/vyos-github-actions/...` — some legacy repos may still be pinned here.
 - The `scripts/override-default` and `scripts/transclude-template` are kept in sync with the copies in `vyos/.github/scripts/`. If you change one, change the other (or migrate fully to `vyos/.github`).


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
