### PR TITLE
ci: T8615: fix broken unused-imports and assign_reviewer workflows

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -17,11 +17,38 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   # https://github.com/shufo/auto-assign-reviewer-by-files
+  #
+  # Auth: mint a vyos-bot[bot] App-installation token via the central
+  # composite action at vyos/.github/.github/actions/get-token@current.
+  # Replaces the prior classic PAT (secrets.PR_ACTION_ASSIGN_REVIEWERS)
+  # which the VyOS-Networks enterprise rejects because its lifetime
+  # exceeds the 90-day cap on classic PATs ("The 'VyOS Networks'
+  # enterprise forbids access via a personal access tokens (classic)
+  # if the token's lifetime is greater than 90 days").
+  #
+  # vyos-bot App permissions include `pull_requests: read+write`, which
+  # is sufficient for shufo/auto-assign-reviewer-by-files to assign
+  # reviewers and read the team-based config in .github/reviewers.yml.
+  # See https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation
+  # for documentation on GitHub App installation tokens.
   assign_reviewer:
     runs-on: ubuntu-latest
     steps:
+      - name: Mint vyos-bot installation token
+        id: token
+        uses: vyos/.github/.github/actions/get-token@current
+        with:
+          owner: vyos
+          client-id: ${{ vars.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Scope the minted token down to only what shufo needs
+          # (assigning reviewers via the Pull Requests API).
+          # Defense in depth: pull_request_target events expose secrets,
+          # so the narrower the token, the smaller the blast radius if
+          # the downstream action is ever compromised.
+          permissions: '{"pull_requests":"write"}'
       - name: Request review based on files changes and/or groups the author belongs to
         uses: shufo/auto-assign-reviewer-by-files@v1.1.4
         with:
-          token: ${{ secrets.PR_ACTION_ASSIGN_REVIEWERS }}
+          token: ${{ steps.token.outputs.token }}
           config: .github/reviewers.yml

--- a/.github/workflows/unused-imports.yml
+++ b/.github/workflows/unused-imports.yml
@@ -19,4 +19,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install pylint
       - name: Analysing the code with pylint
-        run:  make unused-imports
+        # Original line was `make unused-imports` but this repo has no
+        # Makefile (the target appears to have been copy-pasted from
+        # vyos/vyos-1x which does define it). Invoke pylint directly,
+        # enabling only W0611 (unused-import) per the workflow's intent.
+        # `git ls-files -z` emits NUL-delimited paths so any future
+        # Python file with whitespace in its path is handled safely.
+        run: |
+          if ! git ls-files '*.py' | grep -q .; then
+            echo "No Python files tracked; nothing to check."
+            exit 0
+          fi
+          echo "Checking files:"
+          git ls-files '*.py'
+          git ls-files -z '*.py' | xargs -0 pylint --disable=all --enable=W0611


### PR DESCRIPTION
## What

Fixes two CI workflows in this repo that have been failing on every PR for an extended period. Both surfaced during the [T8615](https://vyos.dev/T8615) Mergify central-config sweep against [#9](https://github.com/vyos/vyos-github-actions/pull/9).

### `.github/workflows/unused-imports.yml`

**Problem**: workflow invoked `make unused-imports` but this repo has no Makefile (grep across full git history confirms no Makefile ever existed). The `unused-imports` target appears to have been copy-pasted from a sister repo (vyos/vyos-1x defines it). Broken since the `T6310: add PR templates` commit `d327ae1` introduced it.

**Fix**: invoke pylint directly, enabling only `W0611` (unused-import) per the workflow's original intent. Use `git ls-files -z` + `xargs -0` so any future Python file with whitespace in its path is handled safely.

### `.github/workflows/auto-author-assign.yml` (`assign_reviewer` job)

**Problem**: `assign_reviewer` authenticated via `secrets.PR_ACTION_ASSIGN_REVIEWERS`, a classic PAT whose lifetime exceeds 90 days. The VyOS-Networks enterprise rejects with:

> The 'VyOS Networks' enterprise forbids access via a personal access tokens (classic) if the token's lifetime is greater than 90 days. Please adjust your token's lifetime at the following URL: https://github.com/settings/tokens/1583410548

**Fix**: swap to a `vyos-bot[bot]` App-installation token minted via the central composite action at [`vyos/.github/.github/actions/get-token@current`](https://github.com/vyos/.github/blob/current/.github/actions/get-token/action.yml) (established 2026-05-26 under Mirror Pipeline Rollout 1a). The minted token is scoped down to `pull_requests: write` only — narrower than the App's default permissions, defense in depth for the `pull_request_target` trigger surface.

The `assign-author` job is **unchanged** — it uses the default `GITHUB_TOKEN` and works correctly. Only the broken `assign_reviewer` job is touched.

## Follow-up (operator action)

The now-orphaned `secrets.PR_ACTION_ASSIGN_REVIEWERS` classic PAT ([token settings link](https://github.com/settings/tokens/1583410548)) can be revoked at operator discretion after this PR lands. The secret can also be removed from the repo's Secrets settings.

## Test plan

- [x] Local YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Phase 0 CR clean (0 findings after round-2 review applied: NUL-delimited xargs + removed internal docs link)
- [ ] Post-merge: next PR opened against `current` should see both `Check for unused imports using Pylint` and `PR Triage / assign_reviewer` pass instead of fail
- [ ] Backfill: re-run failed checks on [#9](https://github.com/vyos/vyos-github-actions/pull/9) after this PR lands

## Security notes

- `unused-imports.yml`: only reads filenames from base-branch tracked files (`git ls-files`) — no `github.event.*` interpolation, no untrusted input.
- `auto-author-assign.yml`: `vars.APP_CLIENT_ID` + `secrets.APP_PRIVATE_KEY` are org-scoped; token mint happens in-job; token output is masked. Token permission is scoped to `pull_requests: write` only (vs. the App's broader default).

Refs: [T8615](https://vyos.dev/T8615) (re-scoped 2026-05-28), [IS-421](https://vyos.atlassian.net/browse/IS-421). Caught while landing [#9](https://github.com/vyos/vyos-github-actions/pull/9).

🤖 Generated by [robots](https://vyos.io)


[IS-421]: https://vyos.atlassian.net/browse/IS-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ