### PR TITLE
ci(security): pin uses: refs to commit SHAs in auto-author-assign.yml

### DIFF
--- a/.github/workflows/auto-author-assign.yml
+++ b/.github/workflows/auto-author-assign.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Assign Author to PR"
-        uses: toshimaru/auto-author-assign@v1.6.2
+        uses: toshimaru/auto-author-assign@2daaeb2988aef24bf37e636fe733f365c046aba0 # v1.6.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,7 +36,7 @@ jobs:
     steps:
       - name: Mint vyos-bot installation token
         id: token
-        uses: vyos/.github/.github/actions/get-token@current
+        uses: vyos/.github/.github/actions/get-token@8a437c7bd8ef6f682f87a428f50e24832a0d316d # current branch HEAD as of 2026-05-28
         with:
           owner: vyos
           client-id: ${{ vars.APP_CLIENT_ID }}
@@ -48,7 +48,7 @@ jobs:
           # the downstream action is ever compromised.
           permissions: '{"pull_requests":"write"}'
       - name: Request review based on files changes and/or groups the author belongs to
-        uses: shufo/auto-assign-reviewer-by-files@v1.1.4
+        uses: shufo/auto-assign-reviewer-by-files@f5f3db9ef06bd72ab6978996988c6462cbdaabf6 # v1.1.4
         with:
           token: ${{ steps.token.outputs.token }}
           config: .github/reviewers.yml


### PR DESCRIPTION
## What

Pin three `uses:` references in `.github/workflows/auto-author-assign.yml` to immutable commit SHAs:

| Ref | Old | New |
|-----|-----|-----|
| `toshimaru/auto-author-assign` | `@v1.6.2` | `@2daaeb2988aef24bf37e636fe733f365c046aba0` |
| `vyos/.github/.github/actions/get-token` | `@current` | `@8a437c7bd8ef6f682f87a428f50e24832a0d316d` |
| `shufo/auto-assign-reviewer-by-files` | `@v1.1.4` | `@f5f3db9ef06bd72ab6978996988c6462cbdaabf6` |

## Why

Addresses [PR #10 CodeRabbit finding](https://github.com/vyos/vyos-github-actions/pull/10#discussion_r3316105021).

The workflow runs on `pull_request_target` and mints a `vyos-bot[bot]` App-installation token from `secrets.APP_PRIVATE_KEY`. Movable refs (semver tags, branches) in a secrets-handling `pull_request_target` workflow are an RCE vector: anyone with push access to the referenced repo can swap the action code and run it with our credentials.

Pinning to a commit SHA freezes the executed code. Tag references are retained as trailing comments for human readability.

## Trade-off on the internal central action

`vyos/.github/.github/actions/get-token@current` is intentionally consumed via `@current` per the Mirror Pipeline Rollout 1a centralization model — when the central action improves, all consumers pick it up automatically.

This PR breaks that pattern for this one consumer because `auto-author-assign.yml` is the highest-trust workflow in this repo (handles `APP_PRIVATE_KEY` directly). The defense-in-depth value of insider-threat protection outweighs the central-update convenience here. Other consumers of `get-token` that don't directly handle the App private key can keep using `@current`.

Operational consequence: when the central action is updated (e.g., new permission scope), this consumer requires a manual SHA bump.

## Test plan

- [x] Phase 0 local CR — 0 findings
- [ ] Post-flip CR review
- [ ] Mergify Configuration changed check passes

Refs: T8615 follow-up

🤖 Generated by [robots](https://vyos.io)
