### PR TITLE
T8943: feat(mirror-rollout-2): adopt uniform wrapper stub

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [production]
+    branches: [rolling, production]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,16 +14,13 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
-      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
Rollout 2 Task 6 PR 3 — second pilot of the canonical stub. This is the only consumer with sync_branches=[production] (vyos-github-actions default branch is production, not rolling). Pre-checks per the canonical-stub permissions fix plan Task 6 Step 1 verified before opening.

Advances: T8943

🤖 Generated by [robots](https://vyos.io)