### PR TITLE
T8943: revert(mirror-rollout-2): roll vyos-github-actions back to post-1b wrapper

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling, production]
+    branches: [production]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,13 +14,16 @@ on:
         type: string
 
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
+      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
PR #16 succeeded source-side but failed mirror auto-merge (run [26696131688](https://github.com/vyos/vyos-github-actions/actions/runs/26696131688)). Root cause: source/target divergence from Rollout 1c — vyos/vyos-github-actions has commit `cc9d5ac` (1c rename), VyOS-Networks/vyos-github-actions has its own commit `cefaa8a` (1c rename applied separately). Mirror PR [VyOS-Networks/vyos-github-actions#12](https://github.com/VyOS-Networks/vyos-github-actions/pull/12) hit GraphQL `Pull Request has merge conflicts (mergePullRequest)` and auto-closed.

Per [canonical-stub permissions fix plan](/Users/syncer/.claude/plans/2026-05-30-canonical-stub-permissions-fix.md) Task 7 failure handling, operator chose option A: revert + exclude from this rollout. A follow-up will reconcile the source/target divergence and retry the canonical-stub migration.

Mirror behavior on vyos/vyos-github-actions returns to byte-identical post-1b state (wrapper, central calls, secrets: inherit).

Advances: T8943

🤖 Generated by [robots](https://vyos.io)