### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->production)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project purpose
-Older standalone repo of reusable GitHub Actions workflows for VyOS. Largely **superseded by `vyos/.github`** (the canonical org-wide reusable-workflow library, default branch `current`). Some the private side-side and legacy repos still consume workflows from here; new work should target `vyos/.github`.
+Older standalone repo of reusable GitHub Actions workflows for VyOS. Largely **superseded by `vyos/.github`** (the canonical org-wide reusable-workflow library, default branch `production`). Some the private side-side and legacy repos still consume workflows from here; new work should target `vyos/.github`.
 
 ## Tech stack
 - GitHub Actions YAML reusable workflows under `.github/workflows/`.
@@ -23,7 +23,7 @@ The Python helper scripts are invoked from the workflows.
 - `README.md` — workflow inventory + usage snippets.
 
 ## Cross-repo context
-- **Superseded by `vyos/.github@current`.** That canonical repo carries 19 workflow files and the modern mirror pipeline (`pr-mirror-repo-sync.yml`). Most active VyOS repos pin `vyos/.github`, not this repo.
+- **Superseded by `vyos/.github@production`.** That canonical repo carries 19 workflow files and the modern mirror pipeline (`pr-mirror-repo-sync.yml`). Most active VyOS repos pin `vyos/.github`, not this repo.
 - The `override-default` and `transclude-template` scripts here are duplicated into `vyos/.github/scripts/` — they are runtime build-time helpers used by `vyos-1x` (XML interface-definition processing) and `vyos-build`.
 ## Conventions
 - Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev).
@@ -31,6 +31,6 @@ The Python helper scripts are invoked from the workflows.
 - Default branch is the legacy default (typically `master`/`main`); confirm via `git ls-remote --symref` before pinning.
 
 ## Notes for future contributors
-- **New reusable workflows belong in `vyos/.github`, not here.** Add them at `vyos/.github/.github/workflows/<name>.yml` on `current`.
+- **New reusable workflows belong in `vyos/.github`, not here.** Add them at `vyos/.github/.github/workflows/<name>.yml` on `production`.
 - Before deleting a workflow from this repo, grep `vyos/*` and an internal repository consumers for `uses: vyos/vyos-github-actions/...` — some legacy repos may still be pinned here.
 - The `scripts/override-default` and `scripts/transclude-template` are kept in sync with the copies in `vyos/.github/scripts/`. If you change one, change the other (or migrate fully to `vyos/.github`).


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)